### PR TITLE
feat: add organization management

### DIFF
--- a/public/mock/dict.json
+++ b/public/mock/dict.json
@@ -1,0 +1,29 @@
+{
+    "list": [
+        {
+            "id": 1,
+            "dict_name": "企业身份",
+            "dict_type": "companyType",
+            "app_code": "admin",
+            "values": [
+                {
+                    "id": 1,
+                    "label": "政府",
+                    "dict_type": "companyType",
+                    "value": "government",
+                    "description": "政府类型",
+                    "sort": 1
+                },
+                {
+                    "id": 2,
+                    "label": "企业",
+                    "dict_type": "companyType",
+                    "value": "enterprise",
+                    "description": "企业类型",
+                    "sort": 2
+                }
+            ]
+        }
+    ],
+    "pageTotal": 1
+}

--- a/public/mock/org.json
+++ b/public/mock/org.json
@@ -1,0 +1,25 @@
+{
+    "list": [
+        {
+            "id": 1,
+            "name": "示例企业",
+            "type": "企业",
+            "province": "北京市",
+            "city": "北京市",
+            "district": "朝阳区",
+            "address": "朝阳路100号",
+            "createTime": "2024-01-01"
+        },
+        {
+            "id": 2,
+            "name": "测试机构",
+            "type": "政府",
+            "province": "上海市",
+            "city": "上海市",
+            "district": "浦东新区",
+            "address": "世纪大道200号",
+            "createTime": "2024-02-01"
+        }
+    ],
+    "pageTotal": 2
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,3 +27,10 @@ export const fetchOrgData = () => {
         method: 'get'
     });
 };
+
+export const fetchDictData = () => {
+    return request({
+        url: './mock/dict.json',
+        method: 'get'
+    });
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,3 +20,10 @@ export const fetchRoleData = () => {
         method: 'get'
     });
 };
+
+export const fetchOrgData = () => {
+    return request({
+        url: './mock/org.json',
+        method: 'get'
+    });
+};

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -31,6 +31,12 @@ export const menuData: Menus[] = [
                 index: '/system-menu',
                 title: '菜单管理',
             },
+            {
+                id: '14',
+                pid: '1',
+                index: '/system-org',
+                title: '组织管理',
+            },
         ],
     },
     {

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -31,16 +31,22 @@ export const menuData: Menus[] = [
                 index: '/system-menu',
                 title: '菜单管理',
             },
-            {
-                id: '14',
-                pid: '1',
-                index: '/system-org',
-                title: '组织管理',
-            },
-        ],
-    },
-    {
-        id: '2',
+              {
+                  id: '14',
+                  pid: '1',
+                  index: '/system-org',
+                  title: '组织管理',
+              },
+              {
+                  id: '15',
+                  pid: '1',
+                  index: '/system-dict',
+                  title: '字典管理',
+              },
+          ],
+      },
+      {
+          id: '2',
         title: '组件',
         index: '2-1',
         icon: 'Calendar',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -51,6 +51,15 @@ const routes: RouteRecordRaw[] = [
                 component: () => import(/* webpackChunkName: "system-menu" */ '../views/system/menu.vue'),
             },
             {
+                path: '/system-org',
+                name: 'system-org',
+                meta: {
+                    title: '组织管理',
+                    permiss: '14',
+                },
+                component: () => import(/* webpackChunkName: "system-org" */ '../views/system/org.vue'),
+            },
+            {
                 path: '/table',
                 name: 'basetable',
                 meta: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -50,20 +50,29 @@ const routes: RouteRecordRaw[] = [
                 },
                 component: () => import(/* webpackChunkName: "system-menu" */ '../views/system/menu.vue'),
             },
-            {
-                path: '/system-org',
-                name: 'system-org',
-                meta: {
-                    title: '组织管理',
-                    permiss: '14',
-                },
-                component: () => import(/* webpackChunkName: "system-org" */ '../views/system/org.vue'),
-            },
-            {
-                path: '/table',
-                name: 'basetable',
-                meta: {
-                    title: '基础表格',
+              {
+                  path: '/system-org',
+                  name: 'system-org',
+                  meta: {
+                      title: '组织管理',
+                      permiss: '14',
+                  },
+                  component: () => import(/* webpackChunkName: "system-org" */ '../views/system/org.vue'),
+              },
+              {
+                  path: '/system-dict',
+                  name: 'system-dict',
+                  meta: {
+                      title: '字典管理',
+                      permiss: '15',
+                  },
+                  component: () => import(/* webpackChunkName: "system-dict" */ '../views/system/dict.vue'),
+              },
+              {
+                  path: '/table',
+                  name: 'basetable',
+                  meta: {
+                      title: '基础表格',
                     permiss: '31',
                 },
                 component: () => import(/* webpackChunkName: "table" */ '../views/table/basetable.vue'),

--- a/src/store/permiss.ts
+++ b/src/store/permiss.ts
@@ -13,6 +13,7 @@ export const usePermissStore = defineStore('permiss', {
                 '11',
                 '12',
                 '13',
+                '14',
                 '2',
                 '21',
                 '22',
@@ -43,7 +44,7 @@ export const usePermissStore = defineStore('permiss', {
                 '65',
                 '66',
             ],
-            user: ['0', '1', '11', '12', '13'],
+            user: ['0', '1', '11', '12', '13', '14'],
         };
         const username = localStorage.getItem('vuems_name');
         console.log(username);

--- a/src/store/permiss.ts
+++ b/src/store/permiss.ts
@@ -12,9 +12,10 @@ export const usePermissStore = defineStore('permiss', {
                 '1',
                 '11',
                 '12',
-                '13',
-                '14',
-                '2',
+                  '13',
+                  '14',
+                  '15',
+                  '2',
                 '21',
                 '22',
                 '23',
@@ -44,7 +45,7 @@ export const usePermissStore = defineStore('permiss', {
                 '65',
                 '66',
             ],
-            user: ['0', '1', '11', '12', '13', '14'],
+            user: ['0', '1', '11', '12', '13', '14', '15'],
         };
         const username = localStorage.getItem('vuems_name');
         console.log(username);

--- a/src/types/dict.ts
+++ b/src/types/dict.ts
@@ -1,0 +1,16 @@
+export interface DictValue {
+    id: number;
+    label: string;
+    dict_type: string;
+    value: string;
+    description: string;
+    sort: number;
+}
+
+export interface DictItem {
+    id: number;
+    dict_name: string;
+    dict_type: string;
+    app_code: string;
+    values: DictValue[];
+}

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -1,0 +1,10 @@
+export interface Organization {
+    id: number;
+    name: string;
+    type: string;
+    province: string;
+    city: string;
+    district: string;
+    address: string;
+    createTime: string;
+}

--- a/src/views/system/dict.vue
+++ b/src/views/system/dict.vue
@@ -1,0 +1,204 @@
+<template>
+    <div>
+        <TableSearch :query="query" :options="searchOpt" :search="handleSearch" />
+        <div class="container">
+            <TableCustom
+                :columns="columns"
+                :tableData="tableData"
+                :total="page.total"
+                :viewFunc="handleView"
+                :delFunc="handleDelete"
+                :editFunc="handleEdit"
+                :page-change="changePage"
+            >
+                <template #toolbarBtn>
+                    <el-button type="warning" :icon="CirclePlusFilled" @click="openAdd">新增</el-button>
+                </template>
+            </TableCustom>
+        </div>
+        <el-dialog :title="isEdit ? '编辑' : '新增'" v-model="visible" width="800px" destroy-on-close
+            :close-on-click-modal="false" @close="closeDialog">
+            <el-form :model="form" label-width="100px">
+                <el-form-item label="字典名称" prop="dict_name">
+                    <el-input v-model="form.dict_name" />
+                </el-form-item>
+                <el-form-item label="字典类型" prop="dict_type">
+                    <el-input v-model="form.dict_type" />
+                </el-form-item>
+                <el-form-item label="所属应用" prop="app_code">
+                    <el-input v-model="form.app_code" />
+                </el-form-item>
+                <el-form-item label="字典值">
+                    <el-button type="primary" size="small" @click="addValue">新增值</el-button>
+                    <el-table :data="form.values" style="width: 100%; margin-top: 10px;">
+                        <el-table-column prop="label" label="标签">
+                            <template #default="scope">
+                                <el-input v-model="scope.row.label" />
+                            </template>
+                        </el-table-column>
+                        <el-table-column prop="value" label="值">
+                            <template #default="scope">
+                                <el-input v-model="scope.row.value" />
+                            </template>
+                        </el-table-column>
+                        <el-table-column prop="description" label="描述">
+                            <template #default="scope">
+                                <el-input v-model="scope.row.description" />
+                            </template>
+                        </el-table-column>
+                        <el-table-column prop="sort" label="排序" width="80">
+                            <template #default="scope">
+                                <el-input-number v-model="scope.row.sort" :min="0" />
+                            </template>
+                        </el-table-column>
+                        <el-table-column label="操作" width="80">
+                            <template #default="scope">
+                                <el-button type="text" @click="removeValue(scope.$index)">删除</el-button>
+                            </template>
+                        </el-table-column>
+                    </el-table>
+                </el-form-item>
+                <el-form-item>
+                    <el-button type="primary" @click="saveData">保 存</el-button>
+                </el-form-item>
+            </el-form>
+        </el-dialog>
+        <el-dialog title="查看详情" v-model="visible1" width="700px" destroy-on-close>
+            <TableDetail :data="viewData">
+                <template #values="{ rows }">
+                    <el-table :data="rows.values" style="width: 100%">
+                        <el-table-column prop="label" label="标签" />
+                        <el-table-column prop="value" label="值" />
+                        <el-table-column prop="description" label="描述" />
+                        <el-table-column prop="sort" label="排序" />
+                    </el-table>
+                </template>
+            </TableDetail>
+        </el-dialog>
+    </div>
+</template>
+
+<script setup lang="ts" name="system-dict">
+import { ref, reactive } from 'vue';
+import { ElMessage } from 'element-plus';
+import { CirclePlusFilled } from '@element-plus/icons-vue';
+import { fetchDictData } from '@/api';
+import TableCustom from '@/components/table-custom.vue';
+import TableDetail from '@/components/table-detail.vue';
+import TableSearch from '@/components/table-search.vue';
+import { FormOptionList } from '@/types/form-option';
+import { DictItem, DictValue } from '@/types/dict';
+
+// 查询相关
+const query = reactive({
+    dict_name: '',
+});
+const searchOpt = ref<FormOptionList[]>([
+    { type: 'input', label: '字典名称：', prop: 'dict_name' }
+]);
+const handleSearch = () => {
+    changePage(1);
+};
+
+// 表格相关
+let columns = ref([
+    { type: 'index', label: '序号', width: 55, align: 'center' },
+    { prop: 'dict_name', label: '字典名称' },
+    { prop: 'dict_type', label: '字典类型' },
+    { prop: 'app_code', label: '所属应用' },
+    { prop: 'operator', label: '操作', width: 250 },
+]);
+const page = reactive({
+    index: 1,
+    size: 10,
+    total: 0,
+});
+const tableData = ref<DictItem[]>([]);
+const getData = async () => {
+    const res = await fetchDictData();
+    let list: DictItem[] = res.data.list;
+    if (query.dict_name) {
+        list = list.filter(item => item.dict_name.includes(query.dict_name));
+    }
+    page.total = list.length;
+    const start = (page.index - 1) * page.size;
+    tableData.value = list.slice(start, start + page.size);
+};
+getData();
+
+const changePage = (val: number) => {
+    page.index = val;
+    getData();
+};
+
+// 新增/编辑相关
+const visible = ref(false);
+const isEdit = ref(false);
+const form = reactive<DictItem>({
+    id: 0,
+    dict_name: '',
+    dict_type: '',
+    app_code: '',
+    values: []
+});
+
+const openAdd = () => {
+    form.id = Date.now();
+    form.dict_name = '';
+    form.dict_type = '';
+    form.app_code = '';
+    form.values = [];
+    isEdit.value = false;
+    visible.value = true;
+};
+
+const handleEdit = (row: DictItem) => {
+    Object.assign(form, JSON.parse(JSON.stringify(row)));
+    isEdit.value = true;
+    visible.value = true;
+};
+
+const addValue = () => {
+    form.values.push({ id: Date.now(), label: '', dict_type: form.dict_type, value: '', description: '', sort: 0 });
+};
+
+const removeValue = (index: number) => {
+    form.values.splice(index, 1);
+};
+
+const saveData = () => {
+    ElMessage.success('操作成功');
+    closeDialog();
+    getData();
+};
+
+const closeDialog = () => {
+    visible.value = false;
+    isEdit.value = false;
+};
+
+// 查看详情
+const visible1 = ref(false);
+const viewData = ref({
+    row: {},
+    list: [] as any[],
+});
+
+const handleView = (row: DictItem) => {
+    viewData.value.row = { ...row };
+    viewData.value.list = [
+        { prop: 'dict_name', label: '字典名称' },
+        { prop: 'dict_type', label: '字典类型' },
+        { prop: 'app_code', label: '所属应用' },
+        { prop: 'values', label: '字典值' },
+    ];
+    visible1.value = true;
+};
+
+// 删除
+const handleDelete = (row: DictItem) => {
+    ElMessage.success('删除成功');
+};
+</script>
+
+<style scoped></style>

--- a/src/views/system/org.vue
+++ b/src/views/system/org.vue
@@ -1,0 +1,149 @@
+<template>
+    <div>
+        <TableSearch :query="query" :options="searchOpt" :search="handleSearch" />
+        <div class="container">
+            <TableCustom :columns="columns" :tableData="tableData" :total="page.total" :viewFunc="handleView"
+                :delFunc="handleDelete" :page-change="changePage" :editFunc="handleEdit">
+                <template #toolbarBtn>
+                    <el-button type="warning" :icon="CirclePlusFilled" @click="visible = true">新增</el-button>
+                </template>
+            </TableCustom>
+        </div>
+        <el-dialog :title="isEdit ? '编辑' : '新增'" v-model="visible" width="700px" destroy-on-close
+            :close-on-click-modal="false" @close="closeDialog">
+            <TableEdit :form-data="rowData" :options="options" :edit="isEdit" :update="updateData" />
+        </el-dialog>
+        <el-dialog title="查看详情" v-model="visible1" width="700px" destroy-on-close>
+            <TableDetail :data="viewData"></TableDetail>
+        </el-dialog>
+    </div>
+</template>
+
+<script setup lang="ts" name="system-org">
+import { ref, reactive } from 'vue';
+import { ElMessage } from 'element-plus';
+import { CirclePlusFilled } from '@element-plus/icons-vue';
+import { Organization } from '@/types/org';
+import { fetchOrgData } from '@/api';
+import TableCustom from '@/components/table-custom.vue';
+import TableDetail from '@/components/table-detail.vue';
+import TableSearch from '@/components/table-search.vue';
+import TableEdit from '@/components/table-edit.vue';
+import { FormOption, FormOptionList } from '@/types/form-option';
+
+// 查询相关
+const query = reactive({
+    name: '',
+});
+const searchOpt = ref<FormOptionList[]>([
+    { type: 'input', label: '组织名称：', prop: 'name' }
+]);
+const handleSearch = () => {
+    changePage(1);
+};
+
+// 表格相关
+let columns = ref([
+    { type: 'index', label: '序号', width: 55, align: 'center' },
+    { prop: 'name', label: '组织名称' },
+    { prop: 'type', label: '组织类型' },
+    { prop: 'province', label: '省' },
+    { prop: 'city', label: '市' },
+    { prop: 'district', label: '区' },
+    { prop: 'address', label: '地址' },
+    { prop: 'createTime', label: '创建时间' },
+    { prop: 'operator', label: '操作', width: 250 },
+]);
+const page = reactive({
+    index: 1,
+    size: 10,
+    total: 0,
+});
+const tableData = ref<Organization[]>([]);
+const getData = async () => {
+    const res = await fetchOrgData();
+    let list: Organization[] = res.data.list;
+    if (query.name) {
+        list = list.filter(item => item.name.includes(query.name));
+    }
+    page.total = list.length;
+    const start = (page.index - 1) * page.size;
+    tableData.value = list.slice(start, start + page.size);
+};
+getData();
+
+const changePage = (val: number) => {
+    page.index = val;
+    getData();
+};
+
+// 新增/编辑弹窗相关
+let options = ref<FormOption>({
+    labelWidth: '100px',
+    span: 12,
+    list: [
+        { type: 'input', label: '组织名称', prop: 'name', required: true },
+        {
+            type: 'select',
+            label: '组织类型',
+            prop: 'type',
+            required: true,
+            opts: [
+                { label: '企业', value: '企业' },
+                { label: '政府', value: '政府' },
+                { label: '其他', value: '其他' },
+            ],
+        },
+        { type: 'input', label: '省', prop: 'province', required: true },
+        { type: 'input', label: '市', prop: 'city', required: true },
+        { type: 'input', label: '区', prop: 'district', required: true },
+        { type: 'input', label: '地址', prop: 'address', required: true },
+        { type: 'date', label: '创建时间', prop: 'createTime', required: true, format: 'YYYY-MM-DD' },
+    ]
+});
+const visible = ref(false);
+const isEdit = ref(false);
+const rowData = ref({});
+const handleEdit = (row: Organization) => {
+    rowData.value = { ...row };
+    isEdit.value = true;
+    visible.value = true;
+};
+const updateData = () => {
+    ElMessage.success('操作成功');
+    closeDialog();
+    getData();
+};
+
+const closeDialog = () => {
+    visible.value = false;
+    isEdit.value = false;
+};
+
+// 查看详情弹窗相关
+const visible1 = ref(false);
+const viewData = ref({
+    row: {},
+    list: [] as any[],
+});
+const handleView = (row: Organization) => {
+    viewData.value.row = { ...row };
+    viewData.value.list = [
+        { prop: 'name', label: '组织名称' },
+        { prop: 'type', label: '组织类型' },
+        { prop: 'province', label: '省' },
+        { prop: 'city', label: '市' },
+        { prop: 'district', label: '区' },
+        { prop: 'address', label: '地址' },
+        { prop: 'createTime', label: '创建时间' },
+    ];
+    visible1.value = true;
+};
+
+// 删除相关
+const handleDelete = (row: Organization) => {
+    ElMessage.success('删除成功');
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add organization management menu and route
- implement organization list with search, pagination, and CRUD dialogs
- mock API and type definitions for organizations

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (command started but stopped during transforming stage)


------
https://chatgpt.com/codex/tasks/task_b_689b075ca1b4832c86697609fccb2efe