### PR TITLE
feat: add permission API module

### DIFF
--- a/src/api/permission.ts
+++ b/src/api/permission.ts
@@ -1,0 +1,56 @@
+import request from '@/utils/request';
+import type { PermissionCreateRequest, PermissionUpdateRequest } from '@/types/permission';
+
+export const getPermission = (id: string) => {
+    return request({
+        url: `/permission/get/${id}`,
+        method: 'post',
+    });
+};
+
+export const listPermissions = (data: Record<string, any>) => {
+    return request({
+        url: '/permission/list',
+        method: 'post',
+        data,
+    });
+};
+
+export const createPermission = (data: PermissionCreateRequest) => {
+    return request({
+        url: '/permission/create',
+        method: 'post',
+        data,
+    });
+};
+
+export const updatePermission = (data: PermissionUpdateRequest) => {
+    return request({
+        url: '/permission/update',
+        method: 'post',
+        data,
+    });
+};
+
+export const deletePermission = (id: string) => {
+    return request({
+        url: `/permission/delete/${id}`,
+        method: 'post',
+    });
+};
+
+export const getPermissionChildren = (data: { parentId: string; type: string }) => {
+    return request({
+        url: '/permission/children',
+        method: 'post',
+        data,
+    });
+};
+
+export const queryPermissionByTreePath = (data: { treePath: string }) => {
+    return request({
+        url: '/permission/treePath',
+        method: 'post',
+        data,
+    });
+};

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,0 +1,14 @@
+export interface PermissionCreateRequest {
+    name: string;
+    code: string;
+    description: string;
+    path: string;
+    parentId: string;
+    type: string;
+    sort: number;
+    disableFlag: number;
+}
+
+export interface PermissionUpdateRequest extends PermissionCreateRequest {
+    id: string;
+}


### PR DESCRIPTION
## Summary
- add permission API client and request types

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a428c25148832cb1422b6573a01a61